### PR TITLE
Fixed typo in custom property

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -150,7 +150,7 @@
   --hover-background-color: var(--darken-1);
 
   --link-color: var(--blue);
-  --button-backgroun-color: var(--blue);
+  --button-background-color: var(--blue);
   --pre-background-color: var(--silver);
 
 


### PR DESCRIPTION
Just a minor typo fix in one of the (commented out) custom properties.
